### PR TITLE
feat: support service offerings in manifest builder

### DIFF
--- a/manifest.config.example.json
+++ b/manifest.config.example.json
@@ -6,7 +6,30 @@
         {
             "name": "MCP",
             "endpoint": "http://localhost:3001",
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "offerings": [
+                {
+                    "serviceId": 1,
+                    "name": "Code Review",
+                    "description": "AI-powered code review with security analysis and best practice suggestions",
+                    "sla": 30,
+                    "requirements": {
+                        "type": "object",
+                        "properties": {
+                            "repo_url": { "type": "string", "description": "Repository URL to review" },
+                            "branch": { "type": "string", "description": "Branch name (defaults to main)" }
+                        },
+                        "required": ["repo_url"]
+                    },
+                    "deliverables": {
+                        "type": "object",
+                        "properties": {
+                            "report": { "type": "string", "description": "Review report in markdown" },
+                            "severity_score": { "type": "number", "description": "Overall severity 0-100" }
+                        }
+                    }
+                }
+            ]
         },
         {
             "name": "A2A",

--- a/scripts/build_manifest.ts
+++ b/scripts/build_manifest.ts
@@ -26,10 +26,20 @@ const OASF_SCHEMA_VERSION = '0.8.0';
 
 // ─── Manifest Types ────────────────────────────────────────────────────────────
 
+interface ServiceOffering {
+  serviceId: number;
+  name: string;
+  description: string;
+  sla?: number;
+  requirements?: Record<string, unknown>;
+  deliverables?: Record<string, unknown>;
+}
+
 interface ManifestService {
   name: string;
   endpoint: string;
   version?: string;
+  offerings?: ServiceOffering[];
 }
 
 interface ManifestContact {
@@ -145,6 +155,30 @@ async function main(): Promise<void> {
     if (!svc.endpoint) {
       warnings.push(`Service "${svc.name}" has no endpoint.`);
     }
+    if (svc.offerings) {
+      for (const offering of svc.offerings) {
+        if (!offering.name) {
+          warnings.push(
+            `Service "${svc.name}" has an offering with serviceId ${offering.serviceId} but no name.`,
+          );
+        }
+        if (!offering.description) {
+          warnings.push(
+            `Service "${svc.name}" offering "${offering.name || offering.serviceId}" has no description.`,
+          );
+        }
+      }
+    }
+  }
+
+  // Check for offerings without on-chain service config match
+  const hasOfferings = manifest.services.some(
+    svc => svc.offerings && svc.offerings.length > 0,
+  );
+  if (!hasOfferings) {
+    warnings.push(
+      'No service offerings declared. Consider adding offerings to describe what each on-chain service provides. See: https://github.com/sasurobert/mx-8004/blob/master/docs/specification.md#74-relationship-offerings-vs-on-chain-services',
+    );
   }
 
   // 4. Write manifest.json
@@ -152,12 +186,18 @@ async function main(): Promise<void> {
   const json = JSON.stringify(manifest, null, 2);
   await fs.writeFile(outputPath, json, 'utf8');
 
+  const totalOfferings = manifest.services.reduce(
+    (sum, svc) => sum + (svc.offerings?.length ?? 0),
+    0,
+  );
+
   console.log(`✅ Manifest written to ${outputPath}`);
   console.log(`   Name: ${manifest.name}`);
   console.log(`   Version: ${manifest.version}`);
   console.log(
     `   Services: ${manifest.services.map(s => s.name).join(', ') || 'none'}`,
   );
+  console.log(`   Offerings: ${totalOfferings}`);
   console.log(`   Skills: ${manifest.oasf.skills.length} categories`);
   console.log(`   Domains: ${manifest.oasf.domains.length} categories`);
   console.log(`   x402 Support: ${manifest.x402Support}`);


### PR DESCRIPTION
## Summary

- Adds `ServiceOffering` type and optional `offerings[]` field to `ManifestService`
- Build script validates offering name/description and warns when no offerings are declared
- Example config shows a complete offering with requirements/deliverables JSON schemas

## Changes

### `scripts/build_manifest.ts`
- New `ServiceOffering` interface (`serviceId`, `name`, `description`, `sla`, `requirements`, `deliverables`)
- `ManifestService.offerings` is now an optional field
- Validation: warns if an offering is missing `name` or `description`
- Validation: warns if no offerings are declared at all (with link to spec)
- Build output now shows offering count

### `manifest.config.example.json`
- MCP service now includes an example offering ("Code Review") with full requirements and deliverables JSON schemas
- Shows new agent builders the pattern immediately

## Why

Agents register on-chain services with just `(service_id, price, token)` — users see "Service #1: 0.05 EGLD" with no context about what they're paying for. This lets agents describe their services in the IPFS manifest they already create at registration.

## Related

- Spec PR: sasurobert/mx-8004#5 — adds Section 7 (Agent Registration Manifest) to the specification